### PR TITLE
Fix #1: Where which-key register has been deprecated

### DIFF
--- a/lua/plugins/which_key.lua
+++ b/lua/plugins/which_key.lua
@@ -1,22 +1,30 @@
 return { -- Useful plugin to show you pending keybinds.
-    'folke/which-key.nvim',
-    event = 'VimEnter', -- Sets the loading event to 'VimEnter'
-    config = function() -- This is the function that runs, AFTER loading
-      require('which-key').setup()
+  'folke/which-key.nvim',
+  event = 'VimEnter', -- Sets the loading event to 'VimEnter'
+  config = function() -- This is the function that runs, AFTER loading
+    require('which-key').setup()
 
-      -- Document existing key chains
-      require('which-key').register {
-        ['<leader>c'] = { name = '[C]ode', _ = 'which_key_ignore' },
-        ['<leader>d'] = { name = '[D]ocument', _ = 'which_key_ignore' },
-        ['<leader>r'] = { name = '[R]ename', _ = 'which_key_ignore' },
-        ['<leader>s'] = { name = '[S]earch', _ = 'which_key_ignore' },
-        ['<leader>w'] = { name = '[W]orkspace', _ = 'which_key_ignore' },
-        ['<leader>t'] = { name = '[T]oggle', _ = 'which_key_ignore' },
-        ['<leader>h'] = { name = 'Git [H]unk', _ = 'which_key_ignore' },
-      }
-      -- visual mode
-      require('which-key').register({
-        ['<leader>h'] = { 'Git [H]unk' },
-      }, { mode = 'v' })
-    end,
-  }
+    -- -- Document existing key chains
+    -- require('which-key').register {
+    --   { '', desc = '<leader>c_', hidden = true },
+    --   { '', desc = '<leader>s_', hidden = true },
+    --   { '', group = '[S]earch' },
+    --   { '', group = '[T]oggle' },
+    --   { '', group = '[W]orkspace' },
+    --   { '', desc = '<leader>t_', hidden = true },
+    --   { '', desc = '<leader>w_', hidden = true },
+    --   { '', desc = '<leader>r_', hidden = true },
+    --   { '', desc = '<leader>h_', hidden = true },
+    --   { '', group = '[D]ocument' },
+    --   { '', group = '[R]ename' },
+    --   { '', desc = '<leader>d_', hidden = true },
+    --   { '', group = 'Git [H]unk' },
+    --   { '', group = '[C]ode' },
+    -- }
+    --
+    -- -- visual mode
+    -- require('which-key').register {
+    --   { '<leader>h', desc = 'Git [H]unk', mode = 'v' },
+    -- }
+  end,
+}


### PR DESCRIPTION
which-key maps for documentation have been deprectaed.

This removes that comment which removes the warning for which-key